### PR TITLE
dynamic import should destructure de default prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ i18next.use(ChainedBackend).init({
         HttpBackend, // if a namespace can't be loaded via normal http-backend loadPath, then the inMemoryLocalBackend will try to return the correct resources
         resourcesToBackend((language, namespace, callback) => {
             import(`./locales/${language}/${namespace}.json`)
-                .then(({ default: resources }) => { // with dynamic import, you have to use the "default" key of the module
+                .then(({ default: resources }) => { // with dynamic import, you have to use the "default" key of the module ( https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#importing_defaults )
                     callback(null, resources)
                 })
                 .catch((error) => {

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ i18next.use(ChainedBackend).init({
         HttpBackend, // if a namespace can't be loaded via normal http-backend loadPath, then the inMemoryLocalBackend will try to return the correct resources
         resourcesToBackend((language, namespace, callback) => {
             import(`./locales/${language}/${namespace}.json`)
-                .then((resources) => {
+                .then(({ default: resources }) => {
                     callback(null, resources)
                 })
                 .catch((error) => {

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ i18next.use(ChainedBackend).init({
         HttpBackend, // if a namespace can't be loaded via normal http-backend loadPath, then the inMemoryLocalBackend will try to return the correct resources
         resourcesToBackend((language, namespace, callback) => {
             import(`./locales/${language}/${namespace}.json`)
-                .then(({ default: resources }) => {
+                .then(({ default: resources }) => { // with dynamic import, you have to use the "default" key of the module
                     callback(null, resources)
                 })
                 .catch((error) => {


### PR DESCRIPTION
According to [the mdn documentation about dynamic import](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#importing_defaults):

> When importing a default export with dynamic imports, it works a bit differently. You need to destructure and rename the "default" key from the returned object. 

Your example does work in webpack, probably due to an implementation based on older specification, but does not work [with rollupjs](https://rollupjs.org/guide/en/#dynamic-import), which seems to be more strict with the standard.

The `default` unpack does work on both though.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided